### PR TITLE
    Fix formatting of C identifiers.

### DIFF
--- a/utf8/ctang-foo.ch
+++ b/utf8/ctang-foo.ch
@@ -3,3 +3,95 @@
 @y
 @d buf_size 1000 /* for \.{CWEAVE} and \.{CTANGLE} */
 @z
+
+@x
+  char *j, *k; /* pointer into |byte_mem| */
+@y
+  char *j, *k; /* pointer into |byte_mem| */
+  char *x[256] = {""};
+  /* this mapping table mirrors encTeX definitions */
+  x[0x80] = "А";
+  x[0xa0] = "а";
+  x[0x81] = "Б";
+  x[0xa1] = "б";
+  x[0x82] = "В";
+  x[0xa2] = "в";
+  x[0x83] = "Г";
+  x[0xa3] = "г";
+  x[0x84] = "Д";
+  x[0xa4] = "д";
+  x[0x85] = "Е";
+  x[0xa5] = "е";
+  x[0xf0] = "Ё";
+  x[0xf1] = "ё";
+  x[0x86] = "Ж";
+  x[0xa6] = "ж";
+  x[0x87] = "З";
+  x[0xa7] = "з";
+  x[0x88] = "И";
+  x[0xa8] = "и";
+  x[0x89] = "Й";
+  x[0xa9] = "й";
+  x[0x8a] = "К";
+  x[0xaa] = "к";
+  x[0x8b] = "Л";
+  x[0xab] = "л";
+  x[0x8c] = "М";
+  x[0xac] = "м";
+  x[0x8d] = "Н";
+  x[0xad] = "н";
+  x[0x8e] = "О";
+  x[0xae] = "о";
+  x[0x8f] = "П";
+  x[0xaf] = "п";
+  x[0x90] = "Р";
+  x[0xe0] = "р";
+  x[0x91] = "С";
+  x[0xe1] = "с";
+  x[0x92] = "Т";
+  x[0xe2] = "т";
+  x[0x93] = "У";
+  x[0xe3] = "у";
+  x[0x94] = "Ф";
+  x[0xe4] = "ф";
+  x[0x95] = "Х";
+  x[0xe5] = "х";
+  x[0x96] = "Ц";
+  x[0xe6] = "ц";
+  x[0x97] = "Ч";
+  x[0xe7] = "ч";
+  x[0x98] = "Ш";
+  x[0xe8] = "ш";
+  x[0x99] = "Щ";
+  x[0xe9] = "щ";
+  x[0x9a] = "Ъ";
+  x[0xea] = "ъ";
+  x[0x9b] = "Ы";
+  x[0xeb] = "ы";
+  x[0x9c] = "Ь";
+  x[0xec] = "ь";
+  x[0x9d] = "Э";
+  x[0xed] = "э";
+  x[0x9e] = "Ю";
+  x[0xee] = "ю";
+  x[0x9f] = "Я";
+  x[0xef] = "я";
+  x[0xfc] = "№";
+  /* This is an example for Polish language:
+    x[0xb1] = "ą";
+    ...
+  */
+@z
+
+@x
+    else C_printf("%s",translit[(unsigned char)(*j)-0200]);
+@y
+    else {
+      int z;
+      for(z = 0x80; z <= 0xff; z++)
+        if (x[z] && (strncmp(j, x[z], strlen(x[z])) == 0))
+          break;
+      C_printf("%s",translit[(unsigned char)z-0200]);
+      j+=strlen(x[z])-1;
+    }
+@z

--- a/utf8/cweav-foo.ch
+++ b/utf8/cweav-foo.ch
@@ -1,4 +1,21 @@
 @x
+@c @<Include files@>@/
+@y
+@c
+#include <wchar.h>
+#include <locale.h>
+#include <wctype.h>
+@<Include files@>@/
+@z
+
+@x
+  argc=ac; argv=av;
+@y
+  setlocale(LC_CTYPE, "en_US.UTF-8");
+  argc=ac; argv=av;
+@z
+
+@x
 @d buf_size 100 /* maximum length of input line, plus one */
 @y
 @d buf_size 1000 /* maximum length of input line, plus one */
@@ -75,6 +92,45 @@ void out(char c)
 @z
 
 @x
+      if (xislower(*p)) { /* not entirely uppercase */
+         delim='\\'; break;
+      }
+@y
+      if (xislower(*p)) { /* not entirely uppercase */
+         delim='\\'; break;
+      }
+      else if (ishigh(*p)) {
+          char my_z;
+          int my_n;
+          int my_i;
+          int my_k;
+          my_n = 0;
+          for (my_i = 6; my_i >= 0; my_i--) { /* count number of 1's after first 1 */
+            my_z = 1 << my_i;
+            if ((my_z & *p) == my_z) my_n++;
+            else break;
+          }
+          wchar_t my_wc = 0;
+          int my_y = my_n;
+          int my_q = my_n;
+          for (my_i = 0; my_i <= my_n; my_i++) { /* loop over all bytes of symbol */
+            for (my_k = 5 - my_y; my_k >= 0; my_k--) { /* loop over all bits */
+              my_z = 1 << my_k;
+              if ((my_z & *p) == my_z) my_wc |= 1 << (6*my_q+my_k);
+            }
+            my_y = 0;
+            my_q--;
+            p++;
+          }
+          p--;
+          if (iswlower(my_wc)) {
+            delim = '\\';
+            break;
+          }
+        }
+@z
+
+@x
       if (b!='0' || force_lines==0) out(b)@;
 @y
       if (b!='0' || force_lines==0) out(b);
@@ -84,4 +140,37 @@ void out(char c)
   else if (b!='|') out(b)
 @y
   else if (b!='|') out(b);
+@z
+
+@x
+        if (xislower(*j)) goto lowcase;
+@y
+        if (xislower(*j)) goto lowcase;
+        else if (ishigh(*j)) {
+          char my_z;
+          int my_n;
+          int my_i;
+          int my_k;
+          my_n = 0;
+          for (my_i = 6; my_i >= 0; my_i--) { /* count number of 1's after first 1 */
+            my_z = 1 << my_i;
+            if ((my_z & *j) == my_z) my_n++;
+            else break;
+          }
+          wchar_t my_wc = 0;
+          int my_y = my_n;
+          int my_q = my_n;
+          for (my_i = 0; my_i <= my_n; my_i++) { /* loop over all bytes of symbol */
+            for (my_k = 5 - my_y; my_k >= 0; my_k--) { /* loop over all bits */
+              my_z = 1 << my_k;
+              if ((my_z & *j) == my_z) my_wc |= 1 << (6*my_q+my_k);
+            }
+            my_y = 0;
+            my_q--;
+            j++;
+          }
+          j--;
+          if (iswlower(my_wc))
+            goto lowcase;
+        }
 @z

--- a/utf8/cweav-foo.ch
+++ b/utf8/cweav-foo.ch
@@ -28,13 +28,15 @@
 @z
 
 @x
+@d is_tiny(p) ((p+1)->byte_start==(p)->byte_start+1)
+@y
+@d is_tiny(p) ((p+1)->byte_start==(p)->byte_start+mblen((p)->byte_start, MB_CUR_MAX))
+@z
+
+@x
 @d out(c) {if (out_ptr>=out_buf_end) break_out(); *(++out_ptr)=c;}
 @y
-@<Predecl...@>=
-void out(char c);
-@ @c
-void out(char c)
-{
+@d out(c) {
   int utf8count = 0;
   for (char *i = out_buf; i<=out_ptr; i++) {
     if ((((eight_bits)(*i) & (1<<7)) &&
@@ -45,7 +47,6 @@ void out(char c)
   if (utf8count>80) break_out();
   *(++out_ptr)=c;
 }
-@ Dummy.
 @z
 
 @x
@@ -86,12 +87,6 @@ void out(char c)
 @z
 
 @x
-  } else if (is_tiny(cur_name)) out('|')@;
-@y
-  } else if (is_tiny(cur_name)) out('|');
-@z
-
-@x
       if (xislower(*p)) { /* not entirely uppercase */
          delim='\\'; break;
       }
@@ -100,46 +95,20 @@ void out(char c)
          delim='\\'; break;
       }
       else if (ishigh(*p)) {
-          char my_z;
-          int my_n;
-          int my_i;
-          int my_k;
-          my_n = 0;
-          for (my_i = 6; my_i >= 0; my_i--) { /* count number of 1's after first 1 */
-            my_z = 1 << my_i;
-            if ((my_z & *p) == my_z) my_n++;
-            else break;
-          }
-          wchar_t my_wc = 0;
-          int my_y = my_n;
-          int my_q = my_n;
-          for (my_i = 0; my_i <= my_n; my_i++) { /* loop over all bytes of symbol */
-            for (my_k = 5 - my_y; my_k >= 0; my_k--) { /* loop over all bits */
-              my_z = 1 << my_k;
-              if ((my_z & *p) == my_z) my_wc |= 1 << (6*my_q+my_k);
-            }
-            my_y = 0;
-            my_q--;
-            p++;
-          }
-          p--;
-          if (iswlower(my_wc)) {
-            delim = '\\';
-            break;
+          wchar_t wc;
+          mbtowc(&wc, p, MB_CUR_MAX);
+          if (iswlower(wc)) {
+            delim = '\\'; break;
           }
         }
 @z
 
 @x
-      if (b!='0' || force_lines==0) out(b)@;
+  out((cur_name->byte_start)[0]);
 @y
-      if (b!='0' || force_lines==0) out(b);
-@z
-
-@x
-  else if (b!='|') out(b)
-@y
-  else if (b!='|') out(b);
+  out((cur_name->byte_start)[0]);
+  for (int w = 1; w < mblen(cur_name->byte_start, MB_CUR_MAX); w++)
+    out((cur_name->byte_start)[w]);
 @z
 
 @x
@@ -147,30 +116,9 @@ void out(char c)
 @y
         if (xislower(*j)) goto lowcase;
         else if (ishigh(*j)) {
-          char my_z;
-          int my_n;
-          int my_i;
-          int my_k;
-          my_n = 0;
-          for (my_i = 6; my_i >= 0; my_i--) { /* count number of 1's after first 1 */
-            my_z = 1 << my_i;
-            if ((my_z & *j) == my_z) my_n++;
-            else break;
-          }
-          wchar_t my_wc = 0;
-          int my_y = my_n;
-          int my_q = my_n;
-          for (my_i = 0; my_i <= my_n; my_i++) { /* loop over all bytes of symbol */
-            for (my_k = 5 - my_y; my_k >= 0; my_k--) { /* loop over all bits */
-              my_z = 1 << my_k;
-              if ((my_z & *j) == my_z) my_wc |= 1 << (6*my_q+my_k);
-            }
-            my_y = 0;
-            my_q--;
-            j++;
-          }
-          j--;
-          if (iswlower(my_wc))
+          wchar_t wc;
+          mbtowc(&wc, j, MB_CUR_MAX);
+          if (iswlower(wc))
             goto lowcase;
         }
 @z


### PR DESCRIPTION
```
If C a lowercase identifier does not contain at least one ASCII lowercase letter, it will be formatted as uppercase identifier.

We use iswlower() library function to properly test if non-ASCII letter is lowercase. For this we manually convert the UTF-8 sequence to wide character.
```
